### PR TITLE
remove leading slash from relative file IRIs

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,22 @@ const contentTypeLookup = require('mime-types').contentType
 const Headers = require('node-fetch').Headers
 const ReadableError = require('readable-error')
 
+function decodeIRI (iri) {
+  // IRIs without file scheme are used directly
+  if (!iri.startsWith('file:')) {
+    return iri
+  }
+
+  const pathname = decodeURIComponent(new URL(iri).pathname)
+
+  // remove the leading slash for IRIs with file scheme and relative path
+  if (!iri.startsWith('file:/')) {
+    return pathname.split('/').slice(1).join('/')
+  }
+
+  return pathname
+}
+
 function text (stream) {
   return new Promise((resolve, reject) => {
     stream.pipe(concatStream({
@@ -35,7 +51,7 @@ function fetch (iri, options) {
   options.method = (options.method || 'GET').toUpperCase()
   options.contentTypeLookup = options.contentTypeLookup || contentTypeLookup
 
-  const pathname = iri.startsWith('file:') ? decodeURIComponent(new URL(iri).pathname) : iri
+  const pathname = decodeIRI(iri)
 
   if (options.method === 'GET') {
     return new Promise((resolve) => {

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -82,6 +82,26 @@ describe('fileFetch', () => {
     })
   })
 
+  it('should read the file content with relative URL and method GET', () => {
+    return fileFetch('file:./test/support/file.txt', {
+      method: 'GET'
+    }).then((res) => {
+      return new Promise((resolve) => {
+        let content = ''
+
+        res.body.on('data', (chunk) => {
+          content += chunk
+        })
+
+        res.body.on('end', () => {
+          assert.strictEqual(content, 'test')
+
+          resolve()
+        })
+      })
+    })
+  })
+
   it('should give a 404 path to non-existent file (method GET)', () => {
     return fileFetch('./test/support/nonexistent-file.txt', {
       method: 'GET'


### PR DESCRIPTION
URLs like `file:./test/support/file.txt` don't work in the latest version. This was working before. This PR adds handling for relative file IRIs and adds a test case.

@brettz9 I guess you were using relative pathes without file scheme, cause your PR also added a test for it. I hope you don't rely on relative file IRIs being translated to absolute pathnames. That was not intended and will change in the next patch version.