### PR TITLE
replaced concat-stream with get-stream and small code cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/bergos/file-fetch",
   "dependencies": {
-    "concat-stream": "^2.0.0",
+    "get-stream": "^5.1.0",
     "mime-types": "^2.1.25",
     "node-fetch": "^2.6.0",
     "readable-error": "^1.0.0"


### PR DESCRIPTION
- replaced `concat-stream` with `get-stream` which is easier to use in async code
- the `text` and `json` functions got so simple not worth a own function -> converted to arrow functions
- changed options to use destructuring
- opened the if/else chain, cause there is a return for all if branches