### PR TITLE
feat: use default content type lookup as fallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ async function fetch (iri, { body, contentTypeLookup = contentType, method = 'GE
   method = method.toUpperCase()
 
   const pathname = decodeIRI(iri)
+  const extension = path.extname(pathname)
 
   if (method === 'GET') {
     return new Promise((resolve) => {
@@ -53,7 +54,7 @@ async function fetch (iri, { body, contentTypeLookup = contentType, method = 'GE
 
       stream.on('open', () => {
         resolve(response(200, stream, {
-          'content-type': contentTypeLookup(path.extname(pathname))
+          'content-type': contentTypeLookup(extension) || contentType(extension)
         }))
       })
     })
@@ -70,7 +71,7 @@ async function fetch (iri, { body, contentTypeLookup = contentType, method = 'GE
     stream.push(null)
 
     return response(200, stream, {
-      'content-type': contentTypeLookup(path.extname(pathname))
+      'content-type': contentTypeLookup(extension) || contentType(extension)
     })
   }
 

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -39,6 +39,30 @@ describe('fileFetch', () => {
     assert.strictEqual(res.headers.get('content-type').split(';').shift(), 'text/plain')
   })
 
+  it('should call user content type lookup', async () => {
+    function contentTypeLookup () {
+      return 'application/ld+json'
+    }
+
+    const res = await fileFetch('file://' + path.join(__dirname, 'support/json.json'), {
+      contentTypeLookup
+    })
+
+    assert.strictEqual(res.headers.get('content-type').split(';').shift(), 'application/ld+json')
+  })
+
+  it('uses default content type lookup when override does not return', async () => {
+    function contentTypeLookup () {
+      return undefined
+    }
+
+    const res = await fileFetch('file://' + path.join(__dirname, 'support/json.json'), {
+      contentTypeLookup
+    })
+
+    assert.strictEqual(res.headers.get('content-type').split(';').shift(), 'application/json')
+  })
+
   it('should read the file content with method GET', async () => {
     const res = await fileFetch('file://' + path.join(__dirname, 'support/file.txt'), {
       method: 'GET'


### PR DESCRIPTION
With this change the user-defined content-type lookup function can return a falsy value, in which case the default will be used.

Currently this is not possible and consumers have to import `mime-types` themselves to run the default lookup