### PR TITLE
Base URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,17 +9,17 @@ const ReadableError = require('readable-error')
 
 const { R_OK } = fs.constants
 
-function decodeIRI (iri, baseURL) {
+function decodeIRI (iri, baseDir) {
   // IRIs without file scheme are used directly
   if (!iri.startsWith('file:')) {
-    return path.join(baseURL, iri)
+    return path.join(baseDir, iri)
   }
 
   const pathname = decodeURIComponent(new URL(iri).pathname)
 
   // remove the leading slash for IRIs with file scheme and relative path
   if (!iri.startsWith('file:/')) {
-    return './' + (path.join(baseURL, '.' + pathname))
+    return './' + (path.join(baseDir, '.' + pathname))
   }
 
   return pathname
@@ -36,11 +36,11 @@ function response (status, body, headers) {
   }
 }
 
-function create (baseURL = '') {
+function create ({ baseDir = '' } = {}) {
   return async function fetch (iri, { body, contentTypeLookup = contentType, method = 'GET' } = {}) {
     method = method.toUpperCase()
 
-    const pathname = decodeIRI(iri, baseURL)
+    const pathname = decodeIRI(iri, baseDir)
     const extension = path.extname(pathname)
 
     if (method === 'GET') {

--- a/index.js
+++ b/index.js
@@ -9,16 +9,17 @@ const ReadableError = require('readable-error')
 
 const { R_OK } = fs.constants
 
-function decodeIRI (iri, baseDir) {
+function decodeIRI (iri, baseDir, baseURL) {
   // IRIs without file scheme are used directly
-  if (!iri.startsWith('file:')) {
+  if (!iri.startsWith('file:') && !baseURL) {
     return path.join(baseDir, iri)
   }
 
-  const pathname = decodeURIComponent(new URL(iri).pathname)
+  const pathname = decodeURIComponent(new URL(iri, baseURL).pathname)
 
   // remove the leading slash for IRIs with file scheme and relative path
-  if (!iri.startsWith('file:/')) {
+  if (!iri.startsWith('file:/') &&
+    (!baseURL || !pathname.startsWith('/'))) {
     return './' + (path.join(baseDir, '.' + pathname))
   }
 
@@ -36,11 +37,11 @@ function response (status, body, headers) {
   }
 }
 
-function create ({ baseDir = '' } = {}) {
+function create ({ baseDir = '', baseURL } = {}) {
   return async function fetch (iri, { body, contentTypeLookup = contentType, method = 'GET' } = {}) {
     method = method.toUpperCase()
 
-    const pathname = decodeIRI(iri, baseDir)
+    const pathname = decodeIRI(iri, baseDir, baseURL)
     const extension = path.extname(pathname)
 
     if (method === 'GET') {

--- a/test/create.js
+++ b/test/create.js
@@ -1,0 +1,58 @@
+const path = require('path')
+const assert = require('assert')
+const { describe, it } = require('mocha')
+const fileFetch = require('..')
+
+describe('create', () => {
+  it('should be a function', () => {
+    assert.strictEqual(typeof fileFetch.create, 'function')
+  })
+
+  it('should read the file content with relative path and method GET', async () => {
+    const fetch = fileFetch.create('test')
+    const res = await fetch('./support/file.txt', {
+      method: 'GET'
+    })
+    return new Promise((resolve) => {
+      let content = ''
+
+      res.body.on('data', (chunk) => {
+        content += chunk
+      })
+
+      res.body.on('end', () => {
+        assert.strictEqual(content, 'test')
+
+        resolve()
+      })
+    })
+  })
+
+  it('should return a response with a readable stream', async () => {
+    const fetch = fileFetch.create('test')
+    const res = await fetch('file://' + path.join(__dirname, 'support/file.txt'))
+    assert(res.body.readable)
+    assert.strictEqual(typeof res.body.pipe, 'function')
+    assert.strictEqual(typeof res.body.read, 'function')
+  })
+
+  it('should read the file content with relative URL and method GET', async () => {
+    const fetch = fileFetch.create('test')
+    const res = await fetch('file:./support/file.txt', {
+      method: 'GET'
+    })
+    return new Promise((resolve) => {
+      let content = ''
+
+      res.body.on('data', (chunk) => {
+        content += chunk
+      })
+
+      res.body.on('end', () => {
+        assert.strictEqual(content, 'test')
+
+        resolve()
+      })
+    })
+  })
+})

--- a/test/create.js
+++ b/test/create.js
@@ -8,66 +8,140 @@ describe('create', () => {
     assert.strictEqual(typeof fileFetch.create, 'function')
   })
 
-  it('should read the file content with relative path and method GET', async () => {
-    const fetch = fileFetch.create({ baseDir: 'test' })
-    const res = await fetch('./support/file.txt', {
-      method: 'GET'
-    })
-    return new Promise((resolve) => {
-      let content = ''
-
-      res.body.on('data', (chunk) => {
-        content += chunk
+  describe('baseDir', function () {
+    it('should read the file content with relative path and method GET', async () => {
+      const fetch = fileFetch.create({ baseDir: 'test' })
+      const res = await fetch('./support/file.txt', {
+        method: 'GET'
       })
+      return new Promise((resolve) => {
+        let content = ''
 
-      res.body.on('end', () => {
-        assert.strictEqual(content, 'test')
+        res.body.on('data', (chunk) => {
+          content += chunk
+        })
 
-        resolve()
+        res.body.on('end', () => {
+          assert.strictEqual(content, 'test')
+
+          resolve()
+        })
+      })
+    })
+
+    it('should return a response with a readable stream', async () => {
+      const fetch = fileFetch.create({ baseDir: 'ignoredForAbsolute' })
+      const res = await fetch(
+        'file://' + path.join(__dirname, 'support/file.txt')
+      )
+      assert(res.body.readable)
+      assert.strictEqual(typeof res.body.pipe, 'function')
+      assert.strictEqual(typeof res.body.read, 'function')
+
+      return new Promise((resolve) => {
+        let content = ''
+
+        res.body.on('data', (chunk) => {
+          content += chunk
+        })
+
+        res.body.on('end', () => {
+          assert.strictEqual(content, 'test')
+
+          resolve()
+        })
+      })
+    })
+
+    it('should read the file content with relative URL and method GET', async () => {
+      const fetch = fileFetch.create({ baseDir: 'test' })
+      const res = await fetch('file:./support/file.txt', {
+        method: 'GET'
+      })
+      return new Promise((resolve) => {
+        let content = ''
+
+        res.body.on('data', (chunk) => {
+          content += chunk
+        })
+
+        res.body.on('end', () => {
+          assert.strictEqual(content, 'test')
+
+          resolve()
+        })
       })
     })
   })
 
-  it('should return a response with a readable stream', async () => {
-    const fetch = fileFetch.create({ baseDir: 'ignoredForAbsolute' })
-    const res = await fetch(
-      'file://' + path.join(__dirname, 'support/file.txt')
-    )
-    assert(res.body.readable)
-    assert.strictEqual(typeof res.body.pipe, 'function')
-    assert.strictEqual(typeof res.body.read, 'function')
-
-    return new Promise((resolve) => {
-      let content = ''
-
-      res.body.on('data', (chunk) => {
-        content += chunk
+  describe('baseURL', function () {
+    it('should read the file content with relative path and method GET', async () => {
+      const fetch = fileFetch.create({
+        baseURL: 'file://' + __dirname + '/' // eslint-disable-line no-path-concat
       })
+      const res = await fetch('./support/file.txt', {
+        method: 'GET'
+      })
+      return new Promise((resolve) => {
+        let content = ''
 
-      res.body.on('end', () => {
-        assert.strictEqual(content, 'test')
+        res.body.on('data', (chunk) => {
+          content += chunk
+        })
 
-        resolve()
+        res.body.on('end', () => {
+          assert.strictEqual(content, 'test')
+
+          resolve()
+        })
       })
     })
-  })
 
-  it('should read the file content with relative URL and method GET', async () => {
-    const fetch = fileFetch.create({ baseDir: 'test' })
-    const res = await fetch('file:./support/file.txt', {
-      method: 'GET'
-    })
-    return new Promise((resolve) => {
-      let content = ''
-
-      res.body.on('data', (chunk) => {
-        content += chunk
+    it('should return a response with a readable stream', async () => {
+      const fetch = fileFetch.create({
+        baseURL: 'file://' + path.join(__dirname, 'support/ignoredForAbsolute.txt')
       })
+      const res = await fetch(
+        'file://' + path.join(__dirname, 'support/file.txt')
+      )
+      assert(res.body.readable)
+      assert.strictEqual(typeof res.body.pipe, 'function')
+      assert.strictEqual(typeof res.body.read, 'function')
 
-      res.body.on('end', () => {
-        assert.strictEqual(content, 'test')
+      return new Promise((resolve) => {
+        let content = ''
 
-        resolve()
+        res.body.on('data', (chunk) => {
+          content += chunk
+        })
+
+        res.body.on('end', () => {
+          assert.strictEqual(content, 'test')
+
+          resolve()
+        })
+      })
+    })
+
+    it('should read the file content with relative URL and method GET', async () => {
+      const fetch = fileFetch.create({
+        baseURL: 'file://' + __dirname + '/' // eslint-disable-line no-path-concat
+      })
+      const res = await fetch('file:./support/file.txt', {
+        method: 'GET'
+      })
+      return new Promise((resolve) => {
+        let content = ''
+
+        res.body.on('data', (chunk) => {
+          content += chunk
+        })
+
+        res.body.on('end', () => {
+          assert.strictEqual(content, 'test')
+
+          resolve()
+        })
       })
     })
   })

--- a/test/create.js
+++ b/test/create.js
@@ -9,7 +9,7 @@ describe('create', () => {
   })
 
   it('should read the file content with relative path and method GET', async () => {
-    const fetch = fileFetch.create('test')
+    const fetch = fileFetch.create({ baseDir: 'test' })
     const res = await fetch('./support/file.txt', {
       method: 'GET'
     })
@@ -29,15 +29,31 @@ describe('create', () => {
   })
 
   it('should return a response with a readable stream', async () => {
-    const fetch = fileFetch.create('test')
-    const res = await fetch('file://' + path.join(__dirname, 'support/file.txt'))
+    const fetch = fileFetch.create({ baseDir: 'ignoredForAbsolute' })
+    const res = await fetch(
+      'file://' + path.join(__dirname, 'support/file.txt')
+    )
     assert(res.body.readable)
     assert.strictEqual(typeof res.body.pipe, 'function')
     assert.strictEqual(typeof res.body.read, 'function')
+
+    return new Promise((resolve) => {
+      let content = ''
+
+      res.body.on('data', (chunk) => {
+        content += chunk
+      })
+
+      res.body.on('end', () => {
+        assert.strictEqual(content, 'test')
+
+        resolve()
+      })
+    })
   })
 
   it('should read the file content with relative URL and method GET', async () => {
-    const fetch = fileFetch.create('test')
+    const fetch = fileFetch.create({ baseDir: 'test' })
     const res = await fetch('file:./support/file.txt', {
       method: 'GET'
     })


### PR DESCRIPTION
Fixes #12.

~I think it may be fine to just use base URL now, as it already effectively is supporting URLs.~

~I also went ahead with a simpler API just accepting a single argument of base URL to the `create` function, thinking that would be the primary purpose, and any future arguments could be added as part of a second object argument. But let me know if you prefer a single argument options signature.~